### PR TITLE
Install data files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ badkeys = "badkeys.runcli:runcli"
 [project.optional-dependencies]
 urllookup = ["binary-file-search"]
 ssh = ["paramiko"]
+
+[tool.setuptools.package-data]
+"badkeys.keydata" = ["*.dat"]


### PR DESCRIPTION
During writing a Gentoo ebuild for `badkeys` in my personal overlay I noticed the `pyproject.toml` doesn't install the data files of the `keydata`-directory leading to runtime errors:

```
$ badkeys foo.pub                             
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.11/badkeys", line 8, in <module>
    sys.exit(runcli())
             ^^^^^^^^
  File "/usr/lib/python3.11/site-packages/badkeys/runcli.py", line 218, in runcli
    r = detectandcheck(fcontent, checks=userchecks)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/badkeys/checks.py", line 216, in detectandcheck
    return checkpubkey(inkey, checks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/badkeys/checks.py", line 148, in checkpubkey
    return _checkkey(key, checks)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/badkeys/checks.py", line 70, in _checkkey
    r["results"] = checkrsa(r["n"], e=r["e"], checks=checks)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/badkeys/checks.py", line 120, in checkrsa
    r = callcheck(n, e=e)
        ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/badkeys/rsakeys/sharedprimes.py", line 17, in sharedprimes
    with open(kp, "rb") as f:
         ^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/python3.11/site-packages/badkeys/keydata/primes4096.dat'
```

This PR fixes this issue and ensures all the data files are installed system wide.