### PR TITLE
Faster generation of the product of all primes

### DIFF
--- a/badkeys/rsakeys/smallfactors.py
+++ b/badkeys/rsakeys/smallfactors.py
@@ -12,10 +12,12 @@ def smallfactors(n, e=0):
     # We calculate this once per program run, we could precalculate the
     # constant, but it's fast enough to calculate on the fly.
     if _smallprimes is None:
-        sp = 2
-        for i in range(3, MAX_PRIME + 1, 2):
-            if gmpy2.is_prime(i):
-                sp *= i
+        sp = 1
+        prime = 2
+        while prime <= MAX_PRIME:
+            sp *= prime
+            prime = gmpy2.next_prime(prime)
+
         _smallprimes = sp
 
     factor = gmpy2.gcd(_smallprimes, n)


### PR DESCRIPTION
The new method is 2.5 times faster.

That code is only run once and was already very fast, so the difference is barely noticeable. It could make a difference if we increase `MAX_PRIME`. Since `gmpy2.gcd` is very fast, increasing `MAX_PRIME` could make sense.