### PR TITLE
Docker image support

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,77 @@
+---
+name: Create and publish image to GitHub Container Registry
+"on":
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up layer cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Get Git commit timestamps
+        run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        id: push
+        with:
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/build-push-action@v6
         id: push
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
-FROM python:3-slim
+FROM python:3.13-slim
 
-RUN pip install --no-cache-dir badkeys && \
-    badkeys --update-bl-and-urls
+WORKDIR /app
+
+# gmpy2 needs mpfr headers to build
+RUN apt-get update && \
+    apt-get -y install libmpfr-dev libmpc-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --upgrade pip
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN pip install --no-cache-dir badkeys
+RUN badkeys --update-bl-and-urls
 
 CMD ["badkeys"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get -y install libmpfr-dev libmpc-dev && \
     rm -rf /var/lib/apt/lists/* && \
-    python -m pip install --upgrade pip
+    python -m pip install --root-user-action --upgrade pip
 
 COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --root-user-action --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN pip install --no-cache-dir badkeys
+RUN pip install --root-user-action --no-cache-dir badkeys
 RUN badkeys --update-bl-and-urls
 
 CMD ["badkeys"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . .
 RUN pip install --root-user-action --no-cache-dir badkeys
 RUN badkeys --update-bl-and-urls
 
-CMD ["badkeys"]
+ENTRYPOINT ["badkeys"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3-slim
+
+RUN pip install --no-cache-dir badkeys && \
+    badkeys --update-bl-and-urls
+
+CMD ["badkeys"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get -y install libmpfr-dev libmpc-dev && \
     rm -rf /var/lib/apt/lists/* && \
-    python -m pip install --root-user-action --upgrade pip
+    python -m pip install --root-user-action ignore --upgrade pip
 
 COPY requirements.txt requirements.txt
-RUN pip install --root-user-action --no-cache-dir -r requirements.txt
+RUN pip install --root-user-action ignore --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN pip install --root-user-action --no-cache-dir badkeys
+RUN pip install --root-user-action ignore --no-cache-dir badkeys
 RUN badkeys --update-bl-and-urls
 
 ENTRYPOINT ["badkeys"]


### PR DESCRIPTION
Hey,

not sure how you feel about the idea, but did you think about adding a Dockerfile?
Usage could be something like `docker run -it --rm ghcr.io/nettnikl/badkeys:main --help`.

Image size is huge because of the ~100MB python, ~13MB mpfr headers, ~21MB other requirements, and especially 230MB baked in" --update-bl-and-urls" result.

Let me know what you think!